### PR TITLE
Consistency fixes, added more info to Kara40 and ES

### DIFF
--- a/AtlasMaps.lua
+++ b/AtlasMaps.lua
@@ -160,6 +160,7 @@ AtlasMaps = {
 		{ GREY.."3) "..AL["High Priestess A'lathea"], NPC, 92108 };
 		{ GREY.."4) "..AL["Fenektis the Deceiver"], NPC, 92111 };
 		{ GREY.."5) "..AL["Master Raxxieth"], NPC, 92110 };
+		{ "" };
 		{ GREY..INDENT..AL["Trash Mobs"] };
 	};
 	--HateforgeQuarry TurtleWOW
@@ -178,6 +179,7 @@ AtlasMaps = {
 		{ GREY.."3) "..AL["Corrosis"], NPC, 60829 };
 		{ GREY.."4) "..AL["Hatereaver Annihilator"], NPC, 60734 };
 		{ GREY.."5) "..AL["Hargesh Doomcaller"], NPC, 60737 };
+		{ "" };
 		{ GREY..INDENT..AL["Trash Mobs"] };
 	};
 	--KarazhanCrypt TurtleWOW
@@ -198,6 +200,7 @@ AtlasMaps = {
 		{ GREY.."6) "..AL["Commander Andreon"], NPC, 91919 }; -- Commander Andreon not Commander Anderson. AtlasLoot name misstake
 		{ GREY.."7) "..AL["Alarus"], NPC, 91928 };
 		{ GREY.."8) "..AL["Half-Buried Treasure Chest"], OBJECT, 379545 };
+		{ "" };
 		{ GREY..INDENT..AL["Trash Mobs"] };
 	};
 	--CavernsOfTimeBlackMorass TurtleWOW
@@ -218,6 +221,7 @@ AtlasMaps = {
 		{ GREY.."5) "..AL["Mossheart"], NPC, 65124 };
 		{ GREY.."6) "..AL["Antnormi"], NPC, 65125 };
 		{ GREY.."7) "..AL["Rotmaw"], NPC, 65122 };
+		{ "" };
 		{ GREY..INDENT..AL["Trash Mobs"] };
 	};
 	--StormwindVault TurtleWOW
@@ -238,6 +242,7 @@ AtlasMaps = {
 		{ GREY.."5) "..AL["Volkan Cruelblade"], NPC, 80851 };
 		{ GREY.."6) "..AL["Arc'tiras"], NPC, 93107 };
 		{ GREY.."7) "..AL["Vault Armory Equipment"], NPC, -1 };
+		{ "" };
 		{ GREY..INDENT..AL["Trash Mobs"] };
 	};
 		--GilneasCity TurtleWOW
@@ -260,6 +265,7 @@ AtlasMaps = {
 		{ GREY.."6) "..AL["Horsemaster Levvin"], NPC, 61605 };
 		{ GREY.."7) "..AL["Harlow Family Chest"], OBJECT, 2020027 };
 		{ GREY.."8) "..AL["Genn Greymane"], NPC, 61418 };
+		{ "" };
 		{ GREY..INDENT..AL["Trash Mobs"] };
 	};
 		--LowerKara TurtleWOW
@@ -285,6 +291,7 @@ AtlasMaps = {
 		{ GREY..INDENT.."e) "..AL["Obsidian Rod"] };
 		{ GREY..INDENT.."f) "..AL["Duke Rothlen"] };
 		{ GREY.."6) "..AL["Moroes"], NPC, 61226 };
+		{ "" };
 		{ GREY..INDENT..AL["Trash Mobs"] };
 		{ GREY..INDENT..AL["LKH Enchants"] };
 	};
@@ -292,10 +299,12 @@ AtlasMaps = {
 		ZoneName = { AL["Tower of Karazhan"], };
 		Acronym = "Kara40";
 		Location = { AL["Deadwind Pass"], 41};
-		LevelRange = "60";
+		LevelRange = "60+";
 		MinLevel = "60";
 		PlayerLimit = "40";
 		Continent = AL["Eastern Kingdoms"];
+		{ ORNG..AL["Attunement Required"] };
+		{ ORNG..AL["Key"]..": "..AL["Upper Karazhan Tower Key"], ITEM, 61234 };
 		{ BLUE.."A) "..AL["Entrance"] };
 		{ BLUE.."B) "..AL["Connection"] };
 		{ GREY.."1) "..AL["Keeper Gnarlmoon"], NPC, -1 };
@@ -307,7 +316,9 @@ AtlasMaps = {
 		{ GREY.."7) "..AL["Rupturan the Broken"], NPC, -1 };
 		{ GREY.."8) "..AL["Kruul"], NPC, -1 };
 		{ GREY.."9) "..AL["Mephistroth"], NPC, -1 };
+		{ "" };
 		{ GREY..INDENT..AL["Trash Mobs"] };
+		{ GREY..INDENT..AL["Karazhan Sets"] };
 	};
 	-- EmeraldSanctum TurtleWOW
 	EmeraldSanctum = {
@@ -318,6 +329,8 @@ AtlasMaps = {
 		MinLevel = "58";
 		PlayerLimit = "40";
 		Continent = AL["Kalimdor"];
+		{ ORNG..AL["Attunement Required"] };
+		{ ORNG..AL["Key"]..": "..AL["Gemstone of Ysera"], ITEM, 50545 };
 		{ BLUE.."A) "..AL["Entrance"] };
 		{ GREY.."1) "..AL["Erennius"], NPC, 60747 };
 		{ GREY.."2) "..AL["Solnius the Awakener"], NPC, 60748 };
@@ -440,7 +453,7 @@ AtlasMaps = {
 		MinLevel = "50";
 		PlayerLimit = "5";
 		Continent = AL["Kalimdor"];
-		{ ORNG..AL["Key"]..": "..AL["Brazier of Invocation"].." ("..AL["Тier 0.5 Summon"]..")", ITEM, 22057 };
+		{ ORNG..AL["Key"]..": "..AL["Brazier of Invocation"].." ("..AL["Tier 0.5 Summon"]..")", ITEM, 22057 };
 		{ BLUE.."A) "..AL["Entrance"] };
 		{ BLUE.."B) "..AL["Entrance"] };
 		{ BLUE.."C) "..AL["Entrance"] };
@@ -548,22 +561,6 @@ AtlasMaps = {
 		{ BLUE.."A) "..AL["Entrance"] };
 		{ GREY.."1) "..AL["Broodcommander Axelus"] };
 		{ GREY.."2) "..AL["Onyxia"], NPC, 10184 };
-		{ "" };
-		{ "" };
-		{ "" };
-		{ "" };
-		{ "" };
-		{ "" };
-		{ "" };
-		{ "" };
-		{ "" };
-		{ "" };
-		{ "" };
-		{ "" };
-		{ "" };
-		{ "" };
-		{ "" };
-		{ "" };
 		{ "" };
 		{ ORNG..AL["Damage: "]..AL["Fire"] };
 	};
@@ -719,7 +716,7 @@ AtlasMaps = {
 		Continent = AL["Eastern Kingdoms"];
 		{ ORNG..AL["Key"]..": "..AL["Shadowforge Key"], ITEM, 11000 };
 		{ ORNG..AL["Key"]..": "..AL["Prison Cell Key"], ITEM, 11140 };
-		{ ORNG..AL["Key"]..": "..AL["Banner of Provocation"].." ("..AL["Тier 0.5 Summon"]..")", ITEM, 21986 };
+		{ ORNG..AL["Key"]..": "..AL["Banner of Provocation"].." ("..AL["Tier 0.5 Summon"]..")", ITEM, 21986 };
 		{ BLUE.."A) "..AL["Entrance"] };
 		{ GREY.."1) "..AL["Lord Roccor"], NPC, 9025 };
 		{ GREY.."2) "..AL["Kharan Mighthammer"], NPC, 9021 };
@@ -797,7 +794,7 @@ AtlasMaps = {
 		MinLevel = "55";
 		PlayerLimit = "10";
 		Continent = AL["Eastern Kingdoms"];
-		{ ORNG..AL["Key"]..": "..AL["Brazier of Invocation"].." ("..AL["Тier 0.5 Summon"]..")", ITEM, 22057 };
+		{ ORNG..AL["Key"]..": "..AL["Brazier of Invocation"].." ("..AL["Tier 0.5 Summon"]..")", ITEM, 22057 };
 		{ BLUE.."A) "..AL["Entrance"] };
 		{ BLUE.."B) "..AL["Upper Blackrock Spire"].." (UBRS)", ZONE, 1583 };
 		{ BLUE.."C-F) "..AL["Connections"] };
@@ -844,7 +841,7 @@ AtlasMaps = {
 		PlayerLimit = "10";
 		Continent = AL["Eastern Kingdoms"];
 		{ ORNG..AL["Key"]..": "..AL["Seal of Ascension"], ITEM, 12344 };
-		{ ORNG..AL["Key"]..": "..AL["Brazier of Invocation"].." ("..AL["Тier 0.5 Summon"]..")", ITEM, 22057 };
+		{ ORNG..AL["Key"]..": "..AL["Brazier of Invocation"].." ("..AL["Tier 0.5 Summon"]..")", ITEM, 22057 };
 		{ BLUE.."A) "..AL["Entrance"] };
 		{ BLUE.."B) "..AL["Lower Blackrock Spire"].." (LBRS)", ZONE, 1583 };
 		{ BLUE.."C-E) "..AL["Connections"] };
@@ -894,10 +891,6 @@ AtlasMaps = {
 		{ "" };
 		{ GREY..INDENT..AL["Trash Mobs"] };
 		{ GREY..INDENT..AL["Tier 2 Sets"] };
-		{ "" };
-		{ "" };
-		{ "" };
-		{ "" };
 		{ "" };
 		{ ORNG..AL["Damage: "]..AL["Fire"] };
 	};
@@ -1092,7 +1085,7 @@ AtlasMaps = {
 		{ ORNG..AL["Key"]..": "..AL["Skeleton Key"], ITEM, 13704 };
 		{ ORNG..AL["Key"]..": "..AL["Viewing Room Key"].." ("..AL["Viewing Room"]..")", ITEM, 13873 };
 		{ ORNG..AL["Key"]..": "..AL["Blood of Innocents"].." ("..AL["Kirtonos the Herald"]..")", ITEM, 13523 };
-		{ ORNG..AL["Key"]..": "..AL["Brazier of Invocation"].." ("..AL["Тier 0.5 Summon"]..")", ITEM, 22057 };
+		{ ORNG..AL["Key"]..": "..AL["Brazier of Invocation"].." ("..AL["Tier 0.5 Summon"]..")", ITEM, 22057 };
 		{ ORNG..AL["Key"]..": "..AL["Divination Scryer"].." ("..AL["Death Knight Darkreaver"]..")", ITEM, 18746 };
 		{ BLUE.."A) "..AL["Entrance"] };
 		{ BLUE.."B) "..AL["Connection"] };
@@ -1173,7 +1166,7 @@ AtlasMaps = {
 		{ ORNG..AL["Key"]..": "..AL["The Scarlet Key"].." ("..AL["Living Side"]..")", ITEM, 7146 };
 		{ ORNG..AL["Key"]..": "..AL["Key to the City"].." ("..AL["Undead Side"]..")", ITEM, 12382 };
 		{ ORNG..AL["Key"]..": "..AL["Various Postbox Keys"].." ("..AL["Postmaster Malown"]..")" };
-		{ ORNG..AL["Key"]..": "..AL["Brazier of Invocation"].." ("..AL["Тier 0.5 Summon"]..")", ITEM, 22057 };
+		{ ORNG..AL["Key"]..": "..AL["Brazier of Invocation"].." ("..AL["Tier 0.5 Summon"]..")", ITEM, 22057 };
 		{ BLUE.."A) "..AL["Entrance"].." ("..AL["Front"]..")" };
 		{ BLUE.."B) "..AL["Entrance"].." ("..AL["Side"]..")" };
 		{ GREY.."1) "..AL["Skul"].." ("..AL["Rare"]..", "..AL["Varies"]..")", NPC, 10393 };

--- a/Locale/Atlas-enUS.lua
+++ b/Locale/Atlas-enUS.lua
@@ -154,7 +154,7 @@ AL:RegisterTranslations("enUS", function() return {
 	["Connection"] = true;
 	["Connections"] = true;
 	["Damage: "] = true;
-	["Тier 0.5 Summon"] = true;
+	["Tier 0.5 Summon"] = true;
 	["Dungeon Locations"] = true;
 	["Elevator"] = true;
 	["Front"] = true;
@@ -196,6 +196,7 @@ AL:RegisterTranslations("enUS", function() return {
 	["Zul'Gurub Ring Sets"] = true;
 	["Ruins of Ahn'Qiraj Sets"] = true;
 	["Temple of Ahn'Qiraj Sets"] = true;
+	["Karazhan Sets"] = true;
 	["Tier 1 Sets"] = true;
 	["Tier 2 Sets"] = true;
 	["Tier 3 Sets"] = true;
@@ -309,6 +310,7 @@ AL:RegisterTranslations("enUS", function() return {
 	["Class Books"] = true;
 
 	--Emerald Sanctum -- TurtleWOW 1.17.0
+	["Gemstone of Ysera"] = true;
 	["Favor of Erennius (ES Hard Mode)"] = true;
 
 	--****************************
@@ -1372,6 +1374,7 @@ Dependencies: AceLibrary, AceLocale-2.2
 	["Cla'ckora"] = true,
     -- Kara40
     ["Tower of Karazhan"] = true,
+	["Upper Karazhan Tower Key"] = true,
     ["Keeper Gnarlmoon"] = true,
     ["Ley-Watcher Incantagos"] = true,
     ["Anomalus"] = true,

--- a/Locale/Atlas-esES.lua
+++ b/Locale/Atlas-esES.lua
@@ -173,7 +173,7 @@ AL:RegisterTranslations("esES", function() return {
 	["Connection"] = "Conexión";
 	["Connections"] = "Conexiones";
 	["Damage: "] = "Daño: ";
-	["Тier 0.5 Summon"] = "Tier 0.5 Invocación";
+	["Tier 0.5 Summon"] = "Tier 0.5 Invocación";
 	["Dungeon Locations"] = "Localización de las Mazmorras";
 	["Elevator"] = "Acensor";
 	["Front"] = "Frente";

--- a/Locale/Atlas-ruRU.lua
+++ b/Locale/Atlas-ruRU.lua
@@ -134,7 +134,7 @@ AL:RegisterTranslations("ruRU", function() return {
 	["Connection"] = "Соединение";
 	["Connections"] = "Соединения";
 	["Damage: "] = "Урон: ";
-	["Тier 0.5 Summon"] = "Тир 0.5 призыв";
+	["Tier 0.5 Summon"] = "Тир 0.5 призыв";
 	["Dungeon Locations"] = "Зоны подземелий";
 	["Elevator"] = "Лифт";
 	["Front"] = "Главный";

--- a/Locale/Atlas-zhCN.lua
+++ b/Locale/Atlas-zhCN.lua
@@ -155,7 +155,7 @@ AL:RegisterTranslations("zhCN", function() return {
 	["Connection"] = "连接";
 	["Connections"] = "连接点";
 	["Damage: "] = "伤害: ";
-	["Тier 0.5 Summon"] = "T0.5 召唤";
+	["Tier 0.5 Summon"] = "T0.5 召唤";
 	["Dungeon Locations"] = "地下城位置";
 	["Elevator"] = "升降机";
 	["Front"] = "前部";


### PR DESCRIPTION
Hi, I noticed a few things I thought would be nice to fix/change. Thanks for all your work on this addon.
Everything works fine on my end, and I hope it wont cause any bugs.
I didn't do localisation for other languages, I don't know if that matters and what the item names are in other languages.
<hr>

**Kara40**:
- Added "Attunement Required", and link to a key that you get after completing attunement
  - Added key translation only for **enUS** locale
- Changed Kara40 level range from `"60"` to `"60+"` (as it is in every other raid such as BWL, MC, Naxx etc.)
- Added `Karazhan Sets` for easier lookup

**Emerald Sanctum**:
- Added "Attunement Required", and link to a key that you get after completing attunement
  - Added required key translation only for **enUS** locale

**Dungeons**:
- Probably fixed bug with `(ier 0.5 Summon)` text, now it should say `(Tier 0.5 Summon)` as intended
- Added space before `Trash Mobs` for consistency


There's also [pull request #28 in AtlasLoot](https://github.com/Otari98/AtlasLoot/pull/28) that is a direction addition to these changes, I'm just not sure how to reference them correctly, but this should suffice.